### PR TITLE
handle nested paths

### DIFF
--- a/index.js
+++ b/index.js
@@ -95,7 +95,7 @@ ConfigReplace.prototype.processFile = function(config, filePath) {
 
 ConfigReplace.prototype.writeFile = function(destPath, contents) {
   if (!fs.existsSync(path.dirname(destPath))) {
-    fs.mkdirSync(path.dirname(destPath));
+    fs.mkdirpSync(path.dirname(destPath));
   }
 
   fs.writeFileSync(destPath, contents, { encoding: 'utf8' });


### PR DESCRIPTION
Quick fix to handle file paths like: `dir1/dir2/file.js`

Sorry for not providing tests ATM, have a production bug to fix. 
If you need them with this PR can add them in first week of April.
